### PR TITLE
Add JRuby compatibility by working around JRuby bug

### DIFF
--- a/lib/vcard/field.rb
+++ b/lib/vcard/field.rb
@@ -41,6 +41,11 @@ module Vcard
         #   [<group>.]<name>;<pname>=<pvalue>,<pvalue>:<value>
 
         if group
+          if RUBY_PLATFORM == "java" && group.class == Symbol
+            # As of JRuby 1.7.6, String#append(symbol) does not raise.
+            # See https://github.com/jruby/jruby/issues/1177
+            raise TypeError, "can't convert Symbol into String"
+          end
           line << group << "."
         end
 
@@ -88,6 +93,11 @@ module Vcard
           line << value.map { |v| Field.value_str(v) }.join(";")
 
         when Symbol
+          if RUBY_PLATFORM == "java"
+            # As of JRuby 1.7.6, String#append(symbol) does not raise.
+            # See https://github.com/jruby/jruby/issues/1177
+            raise TypeError, "can't convert Symbol into String"
+          end
           line << value
 
         else


### PR DESCRIPTION
As of JRuby 1.7.6, there's a bug where String#concat(Symbol) will not
raise. This adds a workaround to Vcard for this bug until it's fixed
in JRuby.

Separately, the behavior is odd -- why setting fields and values to
symbols is disallowed is unclear, but given that there's tests and
special code to disallow it, I'll stick with consistency for now.
