### PR TITLE
Change field's to accept symbols as values

### DIFF
--- a/lib/vcard/field.rb
+++ b/lib/vcard/field.rb
@@ -41,7 +41,11 @@ module Vcard
         #   [<group>.]<name>;<pname>=<pvalue>,<pvalue>:<value>
 
         if group
-          line << group << "."
+          if group.class == Symbol
+            # Explicitly allow symbols
+            group = group.to_s
+          end
+          line << group.to_str << "."
         end
 
         line << name
@@ -88,7 +92,7 @@ module Vcard
           line << value.map { |v| Field.value_str(v) }.join(";")
 
         when Symbol
-          line << value
+          line << value.to_s
 
         else
           # FIXME - somewhere along here, values with special chars need escaping...

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -107,13 +107,17 @@ class FieldTest < Test::Unit::TestCase
     assert_equal("Z.B", f.group)
     assert_equal("z.b.NAME:z\n", f.encode)
 
-    assert_raises(TypeError) { f.value = :group }
+    f.value = :group
+    assert_equal("Z.B.NAME:group\n", f.encode)
+    f.value = "z"
 
     assert_equal("Z.B", f.group)
 
-    assert_equal("z.b.NAME:z\n", f.encode)
+    assert_equal("Z.B.NAME:z\n", f.encode)
 
-    assert_raises(TypeError) { f.group = :group }
+    f.group = :group
+    assert_equal("group.NAME:z\n", f.encode)
+    f.group = "z.b"
 
     assert_equal("z.b.NAME:z\n", f.encode)
     assert_equal("Z.B", f.group)


### PR DESCRIPTION
This works around an issue with JRuby, which accepted symbols being
appended to strings.
