### PR TITLE
Allow to ignore invalid fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,27 @@ Or install it yourself as:
 
 ## Configuration
 
-You can configure how to make deal with invalid lines.
-Gem supports three behaviors:
+You can configure how to deal with invalid lines. The gem supports three behaviours:
+
 1. `raise_on_invalid_line = true`
-  Vcard::InvalidEncodingError will be races if any invalid line will be found
+
+ Vcard::InvalidEncodingError will be raised if any invalid line is found.
 
 2. `raise_on_invalid_line = false, ignore_invalid_vcards = true`
-  If vcard source has invalid line, then this vcard object will be ignored.
-  In case if you have only one vcard object in your source string, empty array will be returned from `Vcard.decode`
+
+ If the vcard source has an invalid line, this vcard object will be ignored.
+ If you have only one vcard object in your source string, an empty array will be returned from `Vcard.decode`.
 
 3. `raise_on_invalid_line = false, ignore_invalid_vcards = false`
-  vcard will be marked as invalid, invalid field will be ignored, but vcard will be present in `Vcard#decode` results
 
-    Vcard.configure do |config|
-      config.raise_on_invalid_line = false # default true
-      config.ignore_invalid_vcards = false  # default true
-    end
+ If the vcard is marked as invalid, invalid fields will be ignored, but the vcard will be present in the results of `Vcard#decode`.
+
+```
+Vcard.configure do |config|
+  config.raise_on_invalid_line = false # default true
+  config.ignore_invalid_vcards = false # default true
+end
+```
 
 ## Upgrade Notes
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Or install it yourself as:
 
     $ gem install vcard
 
+## Configuration
+
+You can configure how to make deal with invalid lines.
+Gem supports three behaviors:
+1. `raise_on_invalid_line = true`
+  Vcard::InvalidEncodingError will be races if any invalid line will be found
+
+2. `raise_on_invalid_line = false, ignore_invalid_vcards = true`
+  If vcard source has invalid line, then this vcard object will be ignored.
+  In case if you have only one vcard object in your source string, empty array will be returned from `Vcard.decode`
+
+3. `raise_on_invalid_line = false, ignore_invalid_vcards = false`
+  vcard will be marked as invalid, invalid field will be ignored, but vcard will be present in `Vcard#decode` results
+
+    Vcard.configure do |config|
+      config.raise_on_invalid_line = false # default true
+      config.ignore_invalid_vcards = false  # default true
+    end
+
 ## Upgrade Notes
 
 We are no longer testing against Ruby 1.8.7.

--- a/lib/vcard.rb
+++ b/lib/vcard.rb
@@ -7,6 +7,7 @@ require "date"
 require "open-uri"
 require "stringio"
 
+require "vcard/configuration"
 require "vcard/attachment"
 require "vcard/bnf"
 require "vcard/dirinfo"
@@ -285,4 +286,13 @@ module Vcard
     end
     return outer, inner
   end
+
+  def configuration
+    @configuration ||= Configuration.new
+  end
+
+  def configure
+    yield configuration
+  end
+
 end

--- a/lib/vcard/configuration.rb
+++ b/lib/vcard/configuration.rb
@@ -1,0 +1,19 @@
+module Vcard
+  class Configuration
+
+    attr_accessor :raise_on_invalid_line
+    alias_method :raise_on_invalid_line?, :raise_on_invalid_line
+
+    attr_accessor :ignore_invalid_vcards
+    alias_method :ignore_invalid_vcards?, :ignore_invalid_vcards
+
+    def initialize
+      @raise_on_invalid = true
+      @ignore_invalid_vcard = true
+    end
+
+    private
+
+
+  end
+end

--- a/lib/vcard/configuration.rb
+++ b/lib/vcard/configuration.rb
@@ -12,8 +12,5 @@ module Vcard
       @ignore_invalid_vcard = true
     end
 
-    private
-
-
   end
 end

--- a/lib/vcard/dirinfo.rb
+++ b/lib/vcard/dirinfo.rb
@@ -31,14 +31,25 @@ module Vcard
     # Initialize a DirectoryInfo object from +fields+. If +profile+ is
     # specified, check the BEGIN/END fields.
     def initialize(fields, profile = nil) #:nodoc:
-      if fields.detect { |f| ! f.kind_of? DirectoryInfo::Field }
-        raise ArgumentError, "fields must be an array of DirectoryInfo::Field objects"
+      @valid = true
+      @fields = []
+
+      fields.each do |f|
+        raise ArgumentError, "fields must be an array of DirectoryInfo::Field objects" unless f.kind_of? DirectoryInfo::Field
+        if f.valid?
+          @fields << f
+        else
+          @valid = false
+        end
       end
 
       @string = nil # this is used as a flag to indicate that recoding will be necessary
-      @fields = fields
 
       check_begin_end(profile) if profile
+    end
+
+    def valid?
+      @valid
     end
 
     # Decode +card+ into a DirectoryInfo object.

--- a/lib/vcard/vcard.rb
+++ b/lib/vcard/vcard.rb
@@ -659,7 +659,8 @@ module Vcard
       vcards = []
 
       for e in entities
-        vcards.push(new(e.flatten, "VCARD"))
+        vcard  = new(e.flatten, "VCARD")
+        vcards.push(vcard) if vcard.valid? || !::Vcard.configuration.ignore_invalid_vcards?
       end
 
       vcards

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -21,31 +21,31 @@ class FieldTest < Test::Unit::TestCase
   def test_field4
     line = "t;e=a,b: 4 "
     part = Field.decode0(line)
-    assert_equal("4", part[ 3 ])
+    assert_equal("4", part[ 4 ])
   end
 
   def test_field3
     line = "t;e=a,b:4"
     part = Field.decode0(line)
-    assert_equal("4", part[ 3 ])
-    assert_equal( {"E" => [ "a","b" ] }, part[ 2 ])
+    assert_equal("4", part[ 4 ])
+    assert_equal( {"E" => [ "a","b" ] }, part[ 3 ])
   end
 
   def test_field2
     line = "tel;type=work,voice,msg:+1 313 747-4454"
     part = Field.decode0(line)
-    assert_equal("+1 313 747-4454", part[ 3 ])
-    assert_equal( {"TYPE" => [ "work","voice","msg" ] }, part[ 2 ])
+    assert_equal("+1 313 747-4454", part[ 4 ])
+    assert_equal( {"TYPE" => [ "work","voice","msg" ] }, part[ 3 ])
   end
 
   def test_field1
     line = 'ORGANIZER;CN="xxxx, xxxx [SC100:370:EXCH]":MAILTO:xxxx@americasm01.nt.com'
     parts = Field.decode0(line)
 
-    assert_equal(nil, parts[0])
-    assert_equal("ORGANIZER", parts[1])
-    assert_equal({ "CN" => [ "xxxx, xxxx [SC100:370:EXCH]" ] }, parts[2])
-    assert_equal("MAILTO:xxxx@americasm01.nt.com", parts[3])
+    assert_equal(nil, parts[1])
+    assert_equal("ORGANIZER", parts[2])
+    assert_equal({ "CN" => [ "xxxx, xxxx [SC100:370:EXCH]" ] }, parts[3])
+    assert_equal("MAILTO:xxxx@americasm01.nt.com", parts[4])
   end
 
 =begin this can not be done :-(
@@ -67,25 +67,36 @@ class FieldTest < Test::Unit::TestCase
 
   def test_field0
     assert_equal("name:", line = Field.encode0(nil, "name"))
-    assert_equal([ nil, "NAME", {}, ""], Field.decode0(line))
+    assert_equal([ true, nil, "NAME", {}, ""], Field.decode0(line))
 
     assert_equal("name:value", line = Field.encode0(nil, "name", {}, "value"))
-    assert_equal([ nil, "NAME", {}, "value"], Field.decode0(line))
+    assert_equal([ true, nil, "NAME", {}, "value"], Field.decode0(line))
 
     assert_equal("name;encoding=B:dmFsdWU=", line = Field.encode0(nil, "name", { "encoding"=>:b64 }, "value"))
-    assert_equal([ nil, "NAME", { "ENCODING"=>["B"]}, ["value"].pack("m").chomp ], Field.decode0(line))
+    assert_equal([ true, nil, "NAME", { "ENCODING"=>["B"]}, ["value"].pack("m").chomp ], Field.decode0(line))
 
     line = Field.encode0("group", "name", {}, "value")
     assert_equal "group.name:value", line
-    assert_equal [ "GROUP", "NAME", {}, "value"], Field.decode0(line)
+    assert_equal [ true, "GROUP", "NAME", {}, "value"], Field.decode0(line)
   end
 
-  def test_invalid_fields
+  def test_invalid_fields_wih_raise_error
+    Vcard::configuration.raise_on_invalid_line = true
     [
       "g.:",
       ":v",
     ].each do |line|
       assert_raises(::Vcard::InvalidEncodingError) { Field.decode0(line) }
+    end
+  end
+
+  def test_invalid_fields_wihout_raise_error
+    Vcard.configuration.raise_on_invalid_line = false
+    [
+        "g.:",
+        ":v",
+    ].each do |line|
+      assert_nothing_raised { Field.decode0(line) }
     end
   end
 
@@ -96,6 +107,7 @@ class FieldTest < Test::Unit::TestCase
 
   def test_field_modify
     f = Field.create("name")
+
 
     assert_equal("", f.value)
     f.value = ""


### PR DESCRIPTION
In some cases you do not want to loose all data if you have only one invalid field in encoded VCard (especially for multi-contact vcards).

This change add two config parameters
`Vcard.configuration.raise_on_invalid_line (default true)`.
When this parameter is set to true, decode will raise `Vcard::InvalidEncodingError` if found a field that encoded incorrectly (default behavior).
When `raise_on_invalid_line = false`, exception will not be raised but field will be marked as invalid.

With parameter `Vcard.configuration.ignore_invalid_vcards` you can define behavior for invalid fields.
If `ignore_invalid_vcards = true`, then `Vcard.decode` will ignore a vcard that have at least one incorrect field.
With `ignore_invalid_vcards = false`, vcard only invalid fields will be ignored, but vcard will be added to list, returned by `.decode`