### PR TITLE
Wrap lines exactly by a given width (75 by default)

### DIFF
--- a/lib/vcard/field.rb
+++ b/lib/vcard/field.rb
@@ -228,9 +228,10 @@ module Vcard
         Marshal.load(Marshal.dump(self))
       end
 
-      # The String encoding of the Field. The String will be wrapped to a
-      # maximum line width of +width+, where +0+ means no wrapping, and nil is
-      # to accept the default wrapping (75, recommended by RFC2425).
+      # The String encoding of the Field. The String will be wrapped
+      # to a maximum line width of +width+, where +0+ means no
+      # wrapping, and omitting it is to accept the default wrapping
+      # (75, recommended by RFC2425).
       #
       # Note: AddressBook.app 3.0.3 neither understands to unwrap lines when it
       # imports vCards (it treats them as raw new-line characters), nor wraps
@@ -240,13 +241,15 @@ module Vcard
       # FIXME - breaks round-trip encoding, need to change this to not wrap
       # fields that are already wrapped.
       def encode(width=75)
-        l = @line
-        # Wrap to width, unless width is zero.
-        if width > 0
-          l = l.gsub(/.{#{width},#{width}}/) { |m| m + "\n " }
+        l = @line.rstrip
+        if width.zero?
+          l + "\n"
+        elsif width <= 1
+          raise ArgumentError, "#{width} is too narrow"
+        else
+          # Wrap to width
+          l.scan(/\A.{,#{width}}|.{1,#{width - 1}}/).join("\n ") + "\n"
         end
-        # Make sure it's terminated with no more than a single NL.
-        l.gsub(/\s*\z/, "") + "\n"
       end
 
       alias to_s encode

--- a/test/field_test.rb
+++ b/test/field_test.rb
@@ -162,8 +162,11 @@ class FieldTest < Test::Unit::TestCase
     assert_equal("0:xx\n",            Vcard::DirectoryInfo::Field.create("0", "x" * 2).encode(4))
     assert_equal("0:xx\n x\n",        Vcard::DirectoryInfo::Field.create("0", "x" * 3).encode(4))
     assert_equal("0:xx\n xx\n",       Vcard::DirectoryInfo::Field.create("0", "x" * 4).encode(4))
-    assert_equal("0:xx\n xxxx\n",     Vcard::DirectoryInfo::Field.create("0", "x" * 6).encode(4))
-    assert_equal("0:xx\n xxxx\n x\n", Vcard::DirectoryInfo::Field.create("0", "x" * 7).encode(4))
+    assert_equal("0:xx\n xxx\n x\n",  Vcard::DirectoryInfo::Field.create("0", "x" * 6).encode(4))
+    assert_equal("0:xx\n xxx\n xx\n", Vcard::DirectoryInfo::Field.create("0", "x" * 7).encode(4))
+    assert_equal("0:xxxxxxx\n",       Vcard::DirectoryInfo::Field.create("0", "x" * 7).encode(0))
+    assert_equal("0:xxxxxxx\n",       Vcard::DirectoryInfo::Field.create("0", "x" * 7).encode())
+    assert_equal("0:#{"x" * 73}\n #{"x" * 74}\n #{"x" * 53}\n", Vcard::DirectoryInfo::Field.create("0", "x" * 200).encode())
   end
 end
 


### PR DESCRIPTION
encode() currently produces continued lines of 76 (width + 1) characters in length.

I don't really get the FIXME comment.  Can `@line` possibly contain already wrapped lines instead of a single line?