### PR TITLE
Use the default argument in encode()

### DIFF
--- a/lib/vcard/dirinfo.rb
+++ b/lib/vcard/dirinfo.rb
@@ -244,9 +244,9 @@ module Vcard
 
     # The string encoding of the DirectoryInfo. See Field#encode for information
     # about the width parameter.
-    def encode(width=nil)
+    def encode(width=75)
       unless @string
-        @string = @fields.collect { |f| f.encode(width) } . join ""
+        @string = @fields.collect { |f| f.encode(width) }.join ""
       end
       @string
     end
@@ -261,10 +261,10 @@ module Vcard
         raise "No fields to check"
       end
       unless @fields.first.name? "BEGIN"
-        raise "Needs BEGIN, found: #{@fields.first.encode nil}"
+        raise "Needs BEGIN, found: #{@fields.first.encode}"
       end
       unless @fields.last.name? "END"
-        raise "Needs END, found: #{@fields.last.encode nil}"
+        raise "Needs END, found: #{@fields.last.encode}"
       end
       unless @fields.last.value? @fields.first.value
         raise "BEGIN/END mismatch: (#{@fields.first.value} != #{@fields.last.value}"

--- a/lib/vcard/field.rb
+++ b/lib/vcard/field.rb
@@ -239,8 +239,7 @@ module Vcard
       #
       # FIXME - breaks round-trip encoding, need to change this to not wrap
       # fields that are already wrapped.
-      def encode(width=nil)
-        width = 75 unless width
+      def encode(width=75)
         l = @line
         # Wrap to width, unless width is zero.
         if width > 0


### PR DESCRIPTION
As discussed in https://github.com/qoobaa/vcard/pull/32#discussion_r499943498.

Passing nil is no longer supported.