### PR TITLE
Migrate from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  host:
+    name: ${{ matrix.os }} ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        ruby:
+        - '3.0'
+        - '2.7'
+        - '2.6'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - run: ruby --version
+
+      - run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-script: bundle exec rake
-before_install:
-  - gem install bundler
-rvm:
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6


### PR DESCRIPTION
Travis CI is no more.  Let's migrate to GitHub Actions.